### PR TITLE
Add support for no_proxy environment variable

### DIFF
--- a/lib/passport-predix-oauth/strategy.js
+++ b/lib/passport-predix-oauth/strategy.js
@@ -29,12 +29,25 @@ function Strategy(options, verify) {
     //  hopefully they'll fix this one day, in the oauth2 package.
     var originalExecuteRequest = this._oauth2._executeRequest;
     this._oauth2._executeRequest = function( http_library, options, post_body, callback ) {
-      var HttpsProxyAgent = require('https-proxy-agent');
-      if (process.env['https_proxy']) {
-        httpsProxyAgent = new HttpsProxyAgent(process.env['https_proxy']);
-      }
-      options.agent = httpsProxyAgent;
-      return originalExecuteRequest( http_library, options, post_body, callback);
+        if (process.env['https_proxy']) {
+            var whitelist = false;
+            // Check the no_proxy env var for domains/hosts that should NOT use the proxy
+            if(process.env['no_proxy']) {
+                var nops = process.env['no_proxy'].split(',');
+                for(var nop of nops) {
+                    if(options.host.endsWith(nop)) {
+                        whitelist = true;
+                        break;
+                    }
+                }
+            }
+
+            if(!whitelist) {
+                var HttpsProxyAgent = require('https-proxy-agent');
+                options.agent = new HttpsProxyAgent(process.env['https_proxy']);
+            }
+        }
+        return originalExecuteRequest( http_library, options, post_body, callback);
     };
 
     //FIXME: needs to change to the right url


### PR DESCRIPTION
This addresses issues where the Predix UAA server that you need to use should not use a proxy, but the machine that the app is running on has https_proxy set.
To identify the UAA server to not use a proxy, set the no_proxy environment variable (as a comma-separated list) and ensure that the hostname or domain name of the UAA server is included.
